### PR TITLE
Get display terms condense

### DIFF
--- a/rxNorm.Net.Api.Wrapper/rxNorm.Net.Api.Wrapper.Tests/FindRxCUIByStringTests.cs
+++ b/rxNorm.Net.Api.Wrapper/rxNorm.Net.Api.Wrapper.Tests/FindRxCUIByStringTests.cs
@@ -33,7 +33,7 @@ public class FindRxCUIByStringTests
     {
         string[] rxCUIs = await _rxNormClient.FindRxCUIByStringAsync("Advil 200 mg Tab");
 
-        Assert.Equal(0, rxCUIs.Length);
+        Assert.Empty(rxCUIs);
     }
 
     [Fact]

--- a/rxNorm.Net.Api.Wrapper/rxNorm.Net.Api.Wrapper.Tests/GetDisplayTermsTests.cs
+++ b/rxNorm.Net.Api.Wrapper/rxNorm.Net.Api.Wrapper.Tests/GetDisplayTermsTests.cs
@@ -25,15 +25,14 @@ namespace rxNorm.Net.Api.Wrapper.Tests
         }
 
         [Fact]
-        public async void GetDisplayTerms_FindIbuprofen_FindsTerms()
+        public async Task SearchDisplayTermsAsync_FindIbuprofen_FindsTerms()
         {
-            string[] terms = await _rxNormClient.GetDisplayTermsAsync();
+            var terms = await _rxNormClient.SearchDisplayTermsAsync("ibuprofen");
 
-            bool ibuprofenExist = terms.Contains("Ibuprofen");
-
+            bool ibuprofenExist = terms.Any(term => term.Contains("ibuprofen", StringComparison.OrdinalIgnoreCase));
 
             Assert.True(ibuprofenExist);
         }
-	}
+    }
 }
 

--- a/rxNorm.Net.Api.Wrapper/rxNorm.Net.Api.Wrapper.Tests/GetDisplayTermsTests.cs
+++ b/rxNorm.Net.Api.Wrapper/rxNorm.Net.Api.Wrapper.Tests/GetDisplayTermsTests.cs
@@ -1,13 +1,13 @@
 ﻿using System;
 namespace rxNorm.Net.Api.Wrapper.Tests
 {
-	public class GetDisplayTermsTests
-	{
+    public class GetDisplayTermsTests
+    {
         private readonly HttpClient _httpClient;
         private readonly IRxNormClient _rxNormClient;
 
         public GetDisplayTermsTests()
-		{
+        {
             _httpClient = new HttpClient();
 
             _rxNormClient = new RxNormClient(_httpClient);
@@ -20,18 +20,51 @@ namespace rxNorm.Net.Api.Wrapper.Tests
 
             Assert.NotEmpty(terms);
 
-            string firtTerm = terms[0];
-            
+            string firstTerm = terms[0];
+
+            Assert.NotNull(firstTerm);
+        }
+
+        [Fact]
+        public async Task CountDisplayTermsAsync_FindIbuprofen_GetsCount()
+        {
+            int count = await _rxNormClient.CountDisplayTermsAsync("ibuprofen");
+
+            Assert.Equal(30, count); // As of 2024-06-06 there are 30 entries that contain ibuprofen, this will change and the assertion will need to be updated
+
         }
 
         [Fact]
         public async Task SearchDisplayTermsAsync_FindIbuprofen_FindsTerms()
         {
-            var terms = await _rxNormClient.SearchDisplayTermsAsync("ibuprofen");
+            int pageSize = 5;
+
+            var terms = await _rxNormClient.SearchDisplayTermsAsync("ibuprofen", pageSize, 1);
 
             bool ibuprofenExist = terms.Any(term => term.Contains("ibuprofen", StringComparison.OrdinalIgnoreCase));
 
             Assert.True(ibuprofenExist);
+
+            int count = terms.Where(term => term.Contains("ibuprofen", StringComparison.OrdinalIgnoreCase)).Count();
+
+            Assert.True(count <= pageSize);
+        }
+
+        [Fact]
+        public async Task SearchDisplayTermsAsync_FindIbuprofen_CanPaginate()
+        {
+            int pageSize = 5;
+            int totalTerms = await _rxNormClient.CountDisplayTermsAsync("ibuprofen");
+
+            if (totalTerms > 0)
+            {
+                int totalPages = (int)Math.Ceiling((double)totalTerms / pageSize);
+                for (int page = 1; page <= totalPages; page++)
+                {
+                    var terms = await _rxNormClient.SearchDisplayTermsAsync("ibuprofen", pageSize, page);
+                    Assert.NotEmpty(terms);
+                }
+            }
         }
     }
 }

--- a/rxNorm.Net.Api.Wrapper/rxNorm.Net.Api.Wrapper.Tests/GetDisplayTermsTests.cs
+++ b/rxNorm.Net.Api.Wrapper/rxNorm.Net.Api.Wrapper.Tests/GetDisplayTermsTests.cs
@@ -19,7 +19,20 @@ namespace rxNorm.Net.Api.Wrapper.Tests
             string[] terms = await _rxNormClient.GetDisplayTermsAsync();
 
             Assert.NotEmpty(terms);
+
+            string firtTerm = terms[0];
             
+        }
+
+        [Fact]
+        public async void GetDisplayTerms_FindIbuprofen_FindsTerms()
+        {
+            string[] terms = await _rxNormClient.GetDisplayTermsAsync();
+
+            bool ibuprofenExist = terms.Contains("Ibuprofen");
+
+
+            Assert.True(ibuprofenExist);
         }
 	}
 }

--- a/rxNorm.Net.Api.Wrapper/rxNorm.Net.Api.Wrapper/IRxNormClient.cs
+++ b/rxNorm.Net.Api.Wrapper/rxNorm.Net.Api.Wrapper/IRxNormClient.cs
@@ -8,7 +8,8 @@ namespace rxNorm.Net.Api.Wrapper
     {
         Task<string[]> FindRxCUIByStringAsync(string name, int? scopeOfSearch = null, string[] sourceLists = null, int? precision = null);
         Task<string[]> GetDisplayTermsAsync();
-        Task<string[]> SearchDisplayTermsAsync(string searchString);
+        Task<int> CountDisplayTermsAsync(string searchString);
+        Task<string[]> SearchDisplayTermsAsync(string searchString, int pageSize = 10, int pageIndex = 1);
     }
 }
 

--- a/rxNorm.Net.Api.Wrapper/rxNorm.Net.Api.Wrapper/IRxNormClient.cs
+++ b/rxNorm.Net.Api.Wrapper/rxNorm.Net.Api.Wrapper/IRxNormClient.cs
@@ -8,6 +8,7 @@ namespace rxNorm.Net.Api.Wrapper
     {
         Task<string[]> FindRxCUIByStringAsync(string name, int? scopeOfSearch = null, string[] sourceLists = null, int? precision = null);
         Task<string[]> GetDisplayTermsAsync();
+        Task<string[]> SearchDisplayTermsAsync(string searchString);
     }
 }
 

--- a/rxNorm.Net.Api.Wrapper/rxNorm.Net.Api.Wrapper/RxNormClient.cs
+++ b/rxNorm.Net.Api.Wrapper/rxNorm.Net.Api.Wrapper/RxNormClient.cs
@@ -99,15 +99,39 @@ namespace rxNorm.Net.Api.Wrapper
             throw new HttpRequestException($"Invalid status code in the HttpResponseMessage: {response.StatusCode}.");
         }
 
-        public async Task<string[]> SearchDisplayTermsAsync(string searchString)
+        public async Task<int> CountDisplayTermsAsync(string searchString)
+        {
+            int count = 0;
+
+            if (!string.IsNullOrWhiteSpace(searchString))
+            {
+                var allTerms = await GetDisplayTermsAsync();
+
+                if (allTerms != null)
+                {
+                    count = allTerms
+                        .Where(term => term.Contains(searchString, StringComparison.OrdinalIgnoreCase))
+                        .Count();
+                }
+            }
+
+            return count;
+        }
+
+        public async Task<string[]> SearchDisplayTermsAsync(string searchString, int pageSize = 10, int pageIndex = 1)
         {
             if (string.IsNullOrWhiteSpace(searchString))
                 return Array.Empty<string>();
 
             var allTerms = await GetDisplayTermsAsync();
-            var filteredTerms = allTerms.Where(term => term.Contains(searchString, StringComparison.OrdinalIgnoreCase)).ToArray();
 
-            return filteredTerms;
+            var filteredTermsAndPaginated = allTerms
+                .Where(term => term.Contains(searchString, StringComparison.OrdinalIgnoreCase))
+                .Skip((pageIndex - 1) * pageSize)
+                .Take(pageSize)
+                .ToArray();
+
+            return filteredTermsAndPaginated;
         }
 
     }

--- a/rxNorm.Net.Api.Wrapper/rxNorm.Net.Api.Wrapper/RxNormClient.cs
+++ b/rxNorm.Net.Api.Wrapper/rxNorm.Net.Api.Wrapper/RxNormClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text.Json;
@@ -97,5 +98,17 @@ namespace rxNorm.Net.Api.Wrapper
 
             throw new HttpRequestException($"Invalid status code in the HttpResponseMessage: {response.StatusCode}.");
         }
+
+        public async Task<string[]> SearchDisplayTermsAsync(string searchString)
+        {
+            if (string.IsNullOrWhiteSpace(searchString))
+                return Array.Empty<string>();
+
+            var allTerms = await GetDisplayTermsAsync();
+            var filteredTerms = allTerms.Where(term => term.Contains(searchString, StringComparison.OrdinalIgnoreCase)).ToArray();
+
+            return filteredTerms;
+        }
+
     }
 }


### PR DESCRIPTION
The GetDisplayTermsAsync method retrieves all names used by RxNav for auto-completion, resulting in a large list of over 27,000 terms.

To provide a more focused output, the new SearchDisplayTermsAsync method filters this list to include only the names that contain the specified search string. This enhancement improves usability by narrowing down the results to the most relevant terms based on the user's input.

fixes #16 