### PR TITLE
Remove nullable types

### DIFF
--- a/rxNorm.Net.Api.Wrapper/rxNorm.Net.Api.Wrapper.Tests/FindRxCUIByStringTests.cs
+++ b/rxNorm.Net.Api.Wrapper/rxNorm.Net.Api.Wrapper.Tests/FindRxCUIByStringTests.cs
@@ -22,23 +22,25 @@ public class FindRxCUIByStringTests
 
     }
     [Fact]
+    public async void GetRxCUIStatus_ThrowsExceptionForWhitespaceInput()
+    {
+        Assert.Throws<ArgumentException>(() => _rxNormClient.GetRxCUIStatusAsync("  ").GetAwaiter().GetResult());
+    }
+
+    [Fact]
     public async void RxNormIsActive_ReturnsTrue()
     {
         bool? result = await _rxNormClient.RxNormIsActiveAsync("435");
         Assert.True(result);
     }
+
     [Fact]
     public async void RxNormIsActive_ReturnsFalse()
     {
         bool? result = await _rxNormClient.RxNormIsActiveAsync("123456"); //Invalid RxCUI, should return false
         Assert.False(result);
     }
-    [Fact]
-    public async void RxNormIsActive_ReturnsNull()
-    {
-        bool? result = await _rxNormClient.RxNormIsActiveAsync("  "); //Whitespace input, should return null
-        Assert.Null(result);
-    }
+
     [Fact]
     public async void GetRxCUIs_CurrentScopeSearch_FindsMatch()
     {

--- a/rxNorm.Net.Api.Wrapper/rxNorm.Net.Api.Wrapper.Tests/rxNorm.Net.Api.Wrapper.Tests.csproj
+++ b/rxNorm.Net.Api.Wrapper/rxNorm.Net.Api.Wrapper.Tests/rxNorm.Net.Api.Wrapper.Tests.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
-    <ReleaseVersion>1.0.8-preview.2</ReleaseVersion>
+    <ReleaseVersion>1.0.8</ReleaseVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/rxNorm.Net.Api.Wrapper/rxNorm.Net.Api.Wrapper.Tests/rxNorm.Net.Api.Wrapper.Tests.csproj
+++ b/rxNorm.Net.Api.Wrapper/rxNorm.Net.Api.Wrapper.Tests/rxNorm.Net.Api.Wrapper.Tests.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
-    <ReleaseVersion>1.0.8-preview.1</ReleaseVersion>
+    <ReleaseVersion>1.0.8-preview.2</ReleaseVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/rxNorm.Net.Api.Wrapper/rxNorm.Net.Api.Wrapper.Tests/rxNorm.Net.Api.Wrapper.Tests.csproj
+++ b/rxNorm.Net.Api.Wrapper/rxNorm.Net.Api.Wrapper.Tests/rxNorm.Net.Api.Wrapper.Tests.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
-    <ReleaseVersion>1.0.7</ReleaseVersion>
+    <ReleaseVersion>1.0.8-preview.1</ReleaseVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/rxNorm.Net.Api.Wrapper/rxNorm.Net.Api.Wrapper/IRxNormClient.cs
+++ b/rxNorm.Net.Api.Wrapper/rxNorm.Net.Api.Wrapper/IRxNormClient.cs
@@ -16,9 +16,9 @@ namespace rxNorm.Net.Api.Wrapper
 
         Task<List<DrugsCollection>> GetDrugs(string name);
 
-        Task<bool?> RxNormIsActiveAsync(string rxcui);
+        Task<bool> RxNormIsActiveAsync(string rxcui);
 
-        Task<string?> GetRxCUIStatusAsync(string rxcui);
+        Task<string> GetRxCUIStatusAsync(string rxcui);
     }
 }
 

--- a/rxNorm.Net.Api.Wrapper/rxNorm.Net.Api.Wrapper/RxNormClient.cs
+++ b/rxNorm.Net.Api.Wrapper/rxNorm.Net.Api.Wrapper/RxNormClient.cs
@@ -32,10 +32,10 @@ namespace rxNorm.Net.Api.Wrapper
         /// </summary>
         /// <param rxcui="rxcui">The RxNorm concept identifier</param>
         /// <returns>True if the RxNorm concept has an active status, otherwise false.</returns>
-        public async Task<bool?> RxNormIsActiveAsync(string rxcui)
+        public async Task<bool> RxNormIsActiveAsync(string rxcui)
         {
             if (String.IsNullOrWhiteSpace(rxcui))
-                return null;
+               throw new ArgumentException("Value cannot be null or whitespace.");
 
             string url = $"{_options.Host}/rxcui/{rxcui}/historystatus.json";
 
@@ -63,10 +63,11 @@ namespace rxNorm.Net.Api.Wrapper
         /// </summary>
         /// <param rxcui="rxcui">The RxNorm concept identifier</param>
         /// <returns>Description of the concept's status</returns>
-        public async Task<string?> GetRxCUIStatusAsync(string rxcui)
+        public async Task<string> GetRxCUIStatusAsync(string rxcui)
         {
             if (String.IsNullOrWhiteSpace(rxcui))
-                return null;
+                throw new ArgumentException("RxCUI cannot be null or whitespace.");
+
             string url = $"{_options.Host}/rxcui/{rxcui}/historystatus.json";
             var response = await _httpClient.GetAsync(url);
             if (response.StatusCode == System.Net.HttpStatusCode.OK)

--- a/rxNorm.Net.Api.Wrapper/rxNorm.Net.Api.Wrapper/rxNorm.Net.Api.Wrapper.csproj
+++ b/rxNorm.Net.Api.Wrapper/rxNorm.Net.Api.Wrapper/rxNorm.Net.Api.Wrapper.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<Nullable>enable</Nullable>
 		<PackageId>rxNorm.Net.Api.Wrapper</PackageId>
-		<Version>1.0.8-preview.2</Version>
+		<Version>1.0.8</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>RxNorm api client</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Client wrapper for RxNorm Web API</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/COA.Studies</RepositoryUrl>
-		<ReleaseVersion>1.0.8-preview.2</ReleaseVersion>
+		<ReleaseVersion>1.0.8</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="System.Text.Json" Version="6.0.6" />

--- a/rxNorm.Net.Api.Wrapper/rxNorm.Net.Api.Wrapper/rxNorm.Net.Api.Wrapper.csproj
+++ b/rxNorm.Net.Api.Wrapper/rxNorm.Net.Api.Wrapper/rxNorm.Net.Api.Wrapper.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<Nullable>enable</Nullable>
 		<PackageId>rxNorm.Net.Api.Wrapper</PackageId>
-		<Version>1.0.7</Version>
+		<Version>1.0.8-preview.2</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>RxNorm api client</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Client wrapper for RxNorm Web API</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/COA.Studies</RepositoryUrl>
-		<ReleaseVersion>1.0.8-preview.1</ReleaseVersion>
+		<ReleaseVersion>1.0.8-preview.2</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="System.Text.Json" Version="6.0.6" />

--- a/rxNorm.Net.Api.Wrapper/rxNorm.Net.Api.Wrapper/rxNorm.Net.Api.Wrapper.csproj
+++ b/rxNorm.Net.Api.Wrapper/rxNorm.Net.Api.Wrapper/rxNorm.Net.Api.Wrapper.csproj
@@ -10,7 +10,7 @@
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Client wrapper for RxNorm Web API</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/COA.Studies</RepositoryUrl>
-		<ReleaseVersion>1.0.7</ReleaseVersion>
+		<ReleaseVersion>1.0.8-preview.1</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="System.Text.Json" Version="6.0.6" />


### PR DESCRIPTION
Resolves #21 

This PR removes the nullable types the RxNormIsActiveAsync and GetRxCUIStatusAsync methos in the RxNormClient. Now the methods will not return null and instead throw an exception with an error message.

- [ ] Started PR in draft.
- [ ] Stepped through new code line-by-line with the debugger ↪️ 
- [ ] UI changes? Extensively tested with browser dev tools: inspect the markup, look at the console logs, and network requests. 📈 
- [ ] Ran unit or Playwright tests locally (if applicable). 🧪 
- [ ] Captured screenshots 💻 
- [ ] Wrote a great PR description (see [here](https://github.com/UK-SBCoA/COA/wiki/PR-Standards#pr-description)) 🦖 
- [ ] Marked PR as ready for review and moved into `👀 In review`